### PR TITLE
85 bugfix job timeout none is wrongly interpreted as timeout 0

### DIFF
--- a/src/omotes_orchestrator/db_models/job.py
+++ b/src/omotes_orchestrator/db_models/job.py
@@ -49,5 +49,5 @@ class JobDB(Base):
     """Time at which the job is submitted to Celery."""
     running_at: Optional[datetime] = db.Column(db.DateTime(timezone=True))
     """Time at which a Celery worker has started the task for this job."""
-    timeout_after_ms: int = db.Column(db.Integer)
+    timeout_after_ms: Optional[int] = db.Column(db.Integer)
     """Duration the job may run for before being cancelled due to timing out."""

--- a/src/omotes_orchestrator/main.py
+++ b/src/omotes_orchestrator/main.py
@@ -276,10 +276,20 @@ class Orchestrator:
             )
         else:
             logger.debug("New job %s was not yet registered. Registering and submitting.")
+
+            if not job_submission.HasField("timeout_ms"):
+                timeout_after_ms = None
+                logger.warning("New job timeout_ms is unset, "
+                               "registering timeout_after_ms as null.")
+            else:
+                timeout_after_ms = timedelta(
+                    milliseconds=job_submission.timeout_ms
+                )
+
             self.postgresql_if.put_new_job(
                 job_id=job.id,
                 workflow_type=job_submission.workflow_type,
-                timeout_after=timedelta(milliseconds=job_submission.timeout_ms),
+                timeout_after=timeout_after_ms,
             )
             submit = True
 

--- a/src/omotes_orchestrator/timeout_job_manager.py
+++ b/src/omotes_orchestrator/timeout_job_manager.py
@@ -121,13 +121,20 @@ class TimeoutJobManager:
     def job_is_timedout(job: JobDB) -> bool:
         """Check if the job is timed out.
 
+        The check is only executed if the job.status is RUNNING,
+        job.running_at, and job.timeout_after_ms are both not None.
+
         :param job: Database job row
-        :return: True if the job status is RUNNING and the current time exceeds
-        the job running time + configured job timeout delta
+        :return: True if the current time exceeds the
+        job running time + configured job timeout delta
         """
-        if job.status == JobStatus.RUNNING and job.running_at:
+        if (job.status == JobStatus.RUNNING
+                and job.running_at
+                and job.timeout_after_ms is not None):
             job_tz = job.running_at.tzinfo
             cur_time_tz = datetime.now(job_tz)
-            return cur_time_tz > job.running_at + timedelta(milliseconds=job.timeout_after_ms)
+            return cur_time_tz > (
+                job.running_at + timedelta(milliseconds=job.timeout_after_ms)
+            )
         else:
             return False

--- a/unit_test/test_main.py
+++ b/unit_test/test_main.py
@@ -503,6 +503,21 @@ class TimeoutJobManagerTest(unittest.TestCase):
         # Assert
         self.assertTrue(TimeoutJobManager.job_is_timedout(job))
 
+    def test__job_is_timed_out__returns_false_on_timeout_not_set(self) -> None:
+        # Arrange
+        job = JobDB()
+        # Arrange the case where the job should be considered as timed out,
+        # but the check is skipped by job_is_timedout()
+        # because job.timeout_after_ms is not specified.
+        job.running_at = datetime.now() - timedelta(milliseconds=100)
+        job.timeout_after_ms = None
+        job.status = JobStatus.RUNNING
+
+        # Act
+
+        # Assert
+        self.assertFalse(TimeoutJobManager.job_is_timedout(job))
+
 
 class MyTest(unittest.TestCase):
     def test__construct_orchestrator_config__no_exception(self) -> None:


### PR DESCRIPTION
Related to the issue https://github.com/Project-OMOTES/omotes-system/issues/85 
and the PR of https://github.com/Project-OMOTES/omotes-sdk-python/pull/62